### PR TITLE
Clone the node and visually hide it rather than cloning an incomplete set of styles

### DIFF
--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -107,7 +107,6 @@
         if (!el.clone) clone(el);
         if (el.parent.computed.position != 'absolute' &&
             el.parent.computed.position != 'relative') el.parent.node.style.position = 'relative';
-        if (!el.numeric.zIndex) el.node.style.zIndex = 999;
         el.docOffsetTop = getDocOffsetTop(el.node);
         el.parent.height = el.parent.node.offsetHeight;
     }
@@ -186,20 +185,12 @@
     }
 
     function clone(el) {
-        el.clone = document.createElement(el.cell?el.node.tagName:'div');
+        el.clone = el.node.cloneNode(false)
 
         var refElement = el.node.nextSibling || el.node,
             cloneStyle = el.clone.style;
 
-        cloneStyle.height = el.height + 'px';
-        cloneStyle.width = el.width + 'px';
-        cloneStyle.marginTop = el.computed.marginTop;
-        cloneStyle.marginBottom = el.computed.marginBottom;
-        cloneStyle.marginLeft = el.computed.marginLeft;
-        cloneStyle.marginRight = el.computed.marginRight;
-        cloneStyle.padding = cloneStyle.border = cloneStyle.borderSpacing = 0;
-        cloneStyle.fontSize = '1em';
-        cloneStyle.position = 'static';
+        cloneStyle.opacity = 0;
 
         el.node.parentNode.insertBefore(el.clone, refElement);
 


### PR DESCRIPTION
Scenario: You have a parent container with two DOM nodes in it, one `float: left` and one `float: right`. You want to `position: sticky` one of the floated nodes. 

This scenario is supported natively but the polyfill's current behavior inserts a static node of the correct dimensions but neglects it's float. This just shallow clones the node to inherit all of the original positioning. (Though, I suppose we could also just copy over the float as well, instead)

In addition I've removed the z-index declaration which seems arbitrary and should probably be handled in CSS to begin with. (Imagine one has a fixed header with a lower z-index than 999 and you see the problem with that)
