### PR TITLE
Fix IE10 error

### DIFF
--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -222,7 +222,9 @@
     }
 
     function killClone(el) {
-        el.clone.parentNode.removeChild(el.clone);
+        if (el.clone.parentNode != null) {
+            el.clone.parentNode.removeChild(el.clone);
+        }
         el.clone = undefined;
     }
 


### PR DESCRIPTION
**How to reproduce**
Stickyfill.kill();
$('.sticky').Stickyfill();

**The error**
SCRIPT5007: Unable to get property 'removeChild' of undefined or null reference