### PR TITLE
Remove inline 'width:auto'

### DIFF
--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -67,7 +67,7 @@
             rebuild();
             return;
         }
-        
+
         if (win.pageYOffset != scroll.top) {
             updateScrollPos();
             recalcAllPos();
@@ -168,7 +168,6 @@
                 nodeStyle.right = el.offset.right + 'px';
                 nodeStyle.top = el.offset.top + 'px';
                 nodeStyle.bottom = 'auto';
-                nodeStyle.width = 'auto';
                 nodeStyle.marginLeft = 0;
                 nodeStyle.marginRight = 0;
                 nodeStyle.marginTop = 0;
@@ -180,7 +179,6 @@
                 nodeStyle.right = el.box.right + 'px';
                 nodeStyle.top = el.css.top;
                 nodeStyle.bottom = 'auto';
-                nodeStyle.width = 'auto';
                 nodeStyle.marginLeft = 0;
                 nodeStyle.marginRight = 0;
                 nodeStyle.marginTop = 0;
@@ -192,7 +190,6 @@
                 nodeStyle.right = el.offset.right + 'px';
                 nodeStyle.top = 'auto';
                 nodeStyle.bottom = 0;
-                nodeStyle.width = 'auto';
                 nodeStyle.marginLeft = 0;
                 nodeStyle.marginRight = 0;
                 break;
@@ -267,7 +264,7 @@
             },
             nodeOffset = getElementOffset(node),
             parentOffset = getElementOffset(parentNode),
-            
+
             parent = {
                 node: parentNode,
                 css: {
@@ -383,11 +380,11 @@
         if (!initialized) return;
 
         deinitAll();
-        
+
         for (var i = watchArray.length - 1; i >= 0; i--) {
             watchArray[i] = getElementParams(watchArray[i].node);
         }
-        
+
         initAll();
     }
 
@@ -405,7 +402,7 @@
 
     function stop() {
         pause();
-        deinitAll(); 
+        deinitAll();
     }
 
     function kill() {


### PR DESCRIPTION
Setting width explicitly to ‘auto’ collapses some elements with width
set to different value in CSS rules (like tables). In which scenario
‘width’ must be set inline to ‘auto’?
