### PR TITLE
little encoding problem

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
         pkg: grunt.file.readJSON('package.json'),
         banner:
 `/*!
-  * Stickyfill – \`position: sticky\` polyfill
+  * Stickyfill - \`position: sticky\` polyfill
   * v. <%= pkg.version %> | <%= pkg.homepage %>
   * MIT License
   */


### PR DESCRIPTION
on windows i saw "Stickyfill â€“ `position: sticky` polyfill" due to its encoding, not utf8 by default (thanks Microsoft -_-), that's not a problem, it's just ugly :)