### PR TITLE
Set 'void' to return type in types file.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,8 +10,8 @@ export function add(elements: SingleOrMany<HTMLElement>): Sticky[]
 
 export function refreshAll(): void
 
-export function removeOne(element: SingleOrMany<HTMLElement>)
-export function remove(elements: SingleOrMany<HTMLElement>)
-export function removeAll()
+export function removeOne(element: SingleOrMany<HTMLElement>): void
+export function remove(elements: SingleOrMany<HTMLElement>): void
+export function removeAll(): void
 
 export const stickies: Sticky[]


### PR DESCRIPTION
#95 which lacks return-type annotation, implicitly has an 'any' return type. 

Set 'void' to return type in types file.
