### PR TITLE
add forceSticky method

### DIFF
--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -6,6 +6,7 @@
  *    of the polyfill, but the API will remain functional to avoid breaking things.
  */
 let seppuku = false;
+let isInitialized = false;
 
 // Check for existence of window in case this is being imported on the server in an SSR app
 const isWindowDefined = typeof window !== 'undefined';
@@ -322,7 +323,11 @@ const Stickyfill = {
 
     forceSticky () {
         seppuku = false;
-        init();
+
+        if (!isInitialized) {
+            init();
+        }
+
         this.refreshAll();
     },
 
@@ -431,6 +436,8 @@ const Stickyfill = {
  * 6. Setup events (unless the polyfill was disabled)
  */
 function init () {
+    isInitialized = true;
+
     // Watch for scroll position changes and trigger recalc/refresh if needed
     function checkScroll () {
         if (window.pageXOffset != scroll.left) {

--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -6,13 +6,9 @@
  *    of the polyfill, but the API will remain functional to avoid breaking things.
  */
 let seppuku = false;
-let isInitialized = false;
 
-// Check for existence of window in case this is being imported on the server in an SSR app
-const isWindowDefined = typeof window !== 'undefined';
-
-// The polyfill cant’t function properly without `getComputedStyle`.
-if (isWindowDefined && !window.getComputedStyle) seppuku = true;
+// The polyfill can’t function properly without `window` or `window.getComputedStyle`.
+if (typeof window === 'undefined' || !window.getComputedStyle) seppuku = true;
 // Dont’t get in a way if the browser supports `position: sticky` natively.
 else {
     const testNode = document.createElement('div');
@@ -33,6 +29,7 @@ else {
 /*
  * 2. “Global” vars used across the polyfill
  */
+let isInitialized = false;
 
 // Check if Shadow Root constructor exists to make further checks simpler
 const shadowRootExists = typeof ShadowRoot !== 'undefined';
@@ -323,10 +320,7 @@ const Stickyfill = {
 
     forceSticky () {
         seppuku = false;
-
-        if (!isInitialized) {
-            init();
-        }
+        init();
 
         this.refreshAll();
     },
@@ -436,6 +430,10 @@ const Stickyfill = {
  * 6. Setup events (unless the polyfill was disabled)
  */
 function init () {
+    if (isInitialized) {
+        return;
+    }
+
     isInitialized = true;
 
     // Watch for scroll position changes and trigger recalc/refresh if needed
@@ -502,7 +500,7 @@ function init () {
     else startFastCheckTimer();
 }
 
-if (isWindowDefined && !seppuku) init();
+if (!seppuku) init();
 
 
 /*
@@ -511,6 +509,6 @@ if (isWindowDefined && !seppuku) init();
 if (typeof module != 'undefined' && module.exports) {
     module.exports = Stickyfill;
 }
-else if (isWindowDefined) {
-    window.Stickyfill = Stickyfill;
+else {
+    this.Stickyfill = Stickyfill;
 }

--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -7,8 +7,10 @@
  */
 let seppuku = false;
 
+const isWindowDefined = typeof window !== 'undefined';
+
 // The polyfill can’t function properly without `window` or `window.getComputedStyle`.
-if (typeof window === 'undefined' || !window.getComputedStyle) seppuku = true;
+if (!isWindowDefined || !window.getComputedStyle) seppuku = true;
 // Dont’t get in a way if the browser supports `position: sticky` natively.
 else {
     const testNode = document.createElement('div');
@@ -509,6 +511,6 @@ if (!seppuku) init();
 if (typeof module != 'undefined' && module.exports) {
     module.exports = Stickyfill;
 }
-else {
-    this.Stickyfill = Stickyfill;
+else if (isWindowDefined) {
+    window.Stickyfill = Stickyfill;
 }

--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -7,8 +7,11 @@
  */
 let seppuku = false;
 
+// Check for existence of window in case this is being imported on the server in an SSR app
+const isWindowDefined = typeof window !== 'undefined';
+
 // The polyfill cant’t function properly without `getComputedStyle`.
-if (!window.getComputedStyle) seppuku = true;
+if (isWindowDefined && !window.getComputedStyle) seppuku = true;
 // Dont’t get in a way if the browser supports `position: sticky` natively.
 else {
     const testNode = document.createElement('div');
@@ -317,6 +320,12 @@ const Stickyfill = {
     stickies,
     Sticky,
 
+    forceSticky () {
+        seppuku = false;
+        init();
+        this.refreshAll();
+    },
+
     addOne (node) {
         // Check whether it’s a node
         if (!(node instanceof HTMLElement)) {
@@ -486,7 +495,7 @@ function init () {
     else startFastCheckTimer();
 }
 
-if (!seppuku) init();
+if (isWindowDefined && !seppuku) init();
 
 
 /*
@@ -495,6 +504,6 @@ if (!seppuku) init();
 if (typeof module != 'undefined' && module.exports) {
     module.exports = Stickyfill;
 }
-else {
+else if (isWindowDefined) {
     window.Stickyfill = Stickyfill;
 }


### PR DESCRIPTION
Adds a method to force the polyfill to be called -- suggested fix for https://github.com/wilddeer/stickyfill/issues/81

Usage example:

```
Stickyfill.forceSticky();
Stickyfill.add(element, { forceSticky: true });
Stickyfill.addOne(element, { forceSticky: true });
const sticky = new Stickyfill.Sticky(element, { forceSticky: true });
````

Also adds some defensive checks for the existence of `window` so that the package doesn't cause errors when being imported on the server in an SSR app.