### PR TITLE
Improve types for addOne

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,8 @@ export interface Sticky {
 
 type SingleOrMany<T> = T | Iterable<T>
 
-export function addOne(element: SingleOrMany<HTMLElement>): Sticky
+export function addOne(element: HTMLElement): Sticky
+export function addOne(element: SingleOrMany<HTMLElement>): Sticky | undefined
 export function add(elements: SingleOrMany<HTMLElement>): Sticky[]
 
 export function refreshAll(): void


### PR DESCRIPTION
When passing an empty list, undefined is returned. A separate signature is added for the HTMLElement case to document that this case never returns undefined.