### PR TITLE
Polyfill edge because its position:sticky is buggy

### DIFF
--- a/src/stickyfill.js
+++ b/src/stickyfill.js
@@ -27,6 +27,8 @@ else {
     ) seppuku = true;
 }
 
+// Pre-Chromium Edge position: sticky support is bugged but this fixes it (https://stackoverflow.com/questions/52876032/position-sticky-flickers-during-scroll-in-microsoft-edge-but-not-in-other-brow)
+if(window.navigator.userAgent.indexOf("Edge") > -1) seppuku = false;
 
 /*
  * 2. “Global” vars used across the polyfill


### PR DESCRIPTION
MS Edge (Pre-Chromium) has a buggy implementation of `position: sticky` where it flickers when the user scrolls the page.

See: https://stackoverflow.com/questions/52876032/position-sticky-flickers-during-scroll-in-microsoft-edge-but-not-in-other-brow

And https://github.com/WordPress/gutenberg/pull/12241

`position: fixed` does not have this issue.

I was able to fix this bug on my website by adding this polyfill library and modifying it to not seppuku for Edge, hope it helps others too.